### PR TITLE
Add simple course validation

### DIFF
--- a/app/src/main/java/org/sportiduino/app/CardCourseValidationPreference.java
+++ b/app/src/main/java/org/sportiduino/app/CardCourseValidationPreference.java
@@ -5,9 +5,10 @@ import android.util.AttributeSet;
 
 import androidx.preference.DialogPreference;
 
-public class CardDataUrlPreference extends DialogPreference {
+import org.sportiduino.app.Course.CourseType;
 
-    public CardDataUrlPreference(Context context, AttributeSet attrs) {
+public class CardCourseValidationPreference extends DialogPreference {
+    public CardCourseValidationPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
 
         setSummary(getPlaceholderValue());
@@ -20,11 +21,19 @@ public class CardDataUrlPreference extends DialogPreference {
     private String getValueOrPlaceholderValue() {
         String value = getValue();
 
-        if (value.isEmpty()) {
-            value = getPlaceholderValue();
+        if (value != null) {
+            String[] pairs = value.split(":");
+
+            String typeValue = pairs[0];
+
+            if (CourseType.valueOf(typeValue) == CourseType.UNKNOWN) {
+                return getPlaceholderValue();
+            }
+
+            return typeValue;
         }
 
-        return value;
+        return null;
     }
 
     public String getValue() {
@@ -41,7 +50,7 @@ public class CardDataUrlPreference extends DialogPreference {
 
     @Override
     public int getDialogLayoutResource() {
-        return R.layout.preference_card_data_url;
+        return R.layout.preference_card_course_validation;
     }
 
     @Override

--- a/app/src/main/java/org/sportiduino/app/CardCourseValidationPreferenceDialog.java
+++ b/app/src/main/java/org/sportiduino/app/CardCourseValidationPreferenceDialog.java
@@ -1,0 +1,161 @@
+package org.sportiduino.app;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.preference.PreferenceDialogFragmentCompat;
+
+import java.util.ArrayList;
+import java.util.Objects;
+
+import org.sportiduino.app.Course.CourseType;
+
+public class CardCourseValidationPreferenceDialog extends PreferenceDialogFragmentCompat {
+    private static final String SAVE_STATE_TEXT = "CardCourseValidationPreferenceDialogFragment.text";
+    private CourseType cardCourseValidationType = CourseType.UNKNOWN;
+
+    private String cardCoursePoints;
+    private String cardCoursePointsStrictOrder;
+
+    private ArrayList<RadioButton> radioButtons;
+
+    private LinearLayout courseValidationPoints;
+    private TextView courseValidationPointsText;
+
+    private CheckBox courseValidationPointsStrictOrder;
+
+    public static CardCourseValidationPreferenceDialog newInstance(String key) {
+        final CardCourseValidationPreferenceDialog
+            fragment = new CardCourseValidationPreferenceDialog();
+        final Bundle b = new Bundle(1);
+        b.putString(ARG_KEY, key);
+        fragment.setArguments(b);
+        return fragment;
+    }
+
+    private CardCourseValidationPreference getCardCourseValidationPreference() {
+        return (CardCourseValidationPreference) getPreference();
+    }
+
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putCharSequence(SAVE_STATE_TEXT, cardCourseValidationType.toString());
+    }
+
+    @Override
+    protected void onBindDialogView(@NonNull View view) {
+        super.onBindDialogView(view);
+
+        CardCourseValidationPreference preference = getCardCourseValidationPreference();
+
+        if (preference.getValue() != null) {
+            String[] pairs = preference.getValue().split(":");
+
+            if (pairs.length > 0) {
+                cardCourseValidationType = CourseType.valueOf(pairs[0]);
+            }
+
+            if (pairs.length > 1) {
+                cardCoursePoints = pairs[1];
+            }
+
+            if (pairs.length > 2) {
+                cardCoursePointsStrictOrder = pairs[2];
+            }
+
+            for (int i = 0; i < radioButtons.size(); ++i) {
+                if (i == cardCourseValidationType.ordinal()) {
+                    radioButtons.get(i).setChecked(true);
+                    break;
+                }
+            }
+
+            processPoints();
+        }
+    }
+
+    View.OnClickListener radioButtonClickListener = (View view) -> {
+        RadioButton radioButton = (RadioButton) view;
+        radioButtonChecked(radioButton);
+
+        processPoints();
+    };
+
+    private void radioButtonChecked(RadioButton radioButton) {
+        int radioButtonId = radioButton.getId();
+
+        if (radioButtonId == R.id.course_validation_type_rogaining) {
+            cardCourseValidationType = CourseType.ROGAINING;
+        } else if (radioButtonId == R.id.course_validation_type_orienteering) {
+            cardCourseValidationType = CourseType.ORIENTEERING;
+        } else{
+            cardCourseValidationType = CourseType.UNKNOWN;
+        }
+    }
+
+    private void processPoints() {
+        if (cardCourseValidationType == CourseType.ORIENTEERING) {
+            courseValidationPoints.setVisibility(View.VISIBLE);
+        } else {
+            courseValidationPoints.setVisibility(View.GONE);
+        }
+
+        courseValidationPointsText.setText(cardCoursePoints);
+        courseValidationPointsStrictOrder.setChecked(Objects.equals(cardCoursePointsStrictOrder, "1"));
+    }
+
+    @Nullable
+    @Override
+    protected View onCreateDialogView(@NonNull Context context) {
+        LayoutInflater inflater = LayoutInflater.from(context);
+        View view = inflater.inflate(R.layout.preference_card_course_validation, null);
+
+        RadioButton checkboxUnknown = view.findViewById(R.id.course_validation_type_unknown);
+        RadioButton checkboxOrienteering = view.findViewById(R.id.course_validation_type_orienteering);
+        RadioButton checkboxRogaining = view.findViewById(R.id.course_validation_type_rogaining);
+
+        courseValidationPoints = view.findViewById(R.id.course_validation_points);
+        courseValidationPointsText = view.findViewById(R.id.course_validation_points_text);
+        courseValidationPointsStrictOrder = view.findViewById(R.id.course_validation_points_strict_order);
+
+        radioButtons = new ArrayList<>();
+
+        radioButtons.add(checkboxUnknown);
+        radioButtons.add(checkboxOrienteering);
+        radioButtons.add(checkboxRogaining);
+
+        for (int i = 0; i < radioButtons.size(); ++i) {
+            radioButtons.get(i).setOnClickListener(radioButtonClickListener);
+        }
+
+        return view;
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        if (positiveResult) {
+            String type = cardCourseValidationType.toString();
+            String points = courseValidationPointsText.getText().toString();
+            String strictOrder = courseValidationPointsStrictOrder.isChecked() ? "1" : "0";
+
+            CardCourseValidationPreference preference = getCardCourseValidationPreference();
+
+            String newValue = type + ":" + points + ":" + strictOrder;
+
+            if (preference.callChangeListener(newValue)) {
+                preference.setValue(newValue);
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/Course.java
+++ b/app/src/main/java/org/sportiduino/app/Course.java
@@ -1,0 +1,9 @@
+package org.sportiduino.app;
+
+public class Course {
+    public enum CourseType {
+        UNKNOWN,
+        ORIENTEERING,
+        ROGAINING,
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/CourseValidator.java
+++ b/app/src/main/java/org/sportiduino/app/CourseValidator.java
@@ -1,0 +1,118 @@
+package org.sportiduino.app;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.sportiduino.app.Course.CourseType;
+
+public class CourseValidator {
+    private Enum<CourseType> type = CourseType.UNKNOWN;
+
+    private final ArrayList<Integer> coursePoints = new ArrayList<>();
+
+    private ArrayList<Integer> cardPointsRaw = new ArrayList<>();
+    private ArrayList<Integer> cardPoints = new ArrayList<>();
+
+    private Boolean strictOrder = false;
+
+    private CourseValidatorBase validator;
+
+    public CourseValidator(String value) {
+        this.init(value);
+    }
+
+    public void init(String value) {
+        String[] pairs = value.split(":");
+
+        if (pairs.length > 0) {
+            try {
+                type = CourseType.valueOf(pairs[0]);
+            }  catch (Exception ignored) {}
+
+            if (type == CourseType.ROGAINING) {
+                validator = new CourseValidatorRogaining(this);
+            }
+
+            if (type == CourseType.ORIENTEERING) {
+                validator = new CourseValidatorOrienteering(this);
+            }
+        }
+
+        if (pairs.length > 1) {
+            String[] rawPoints = pairs[1].split(",");
+
+            for (String rawPoint : rawPoints) {
+                String point = rawPoint.trim();
+
+                if (!point.isEmpty()) {
+                    coursePoints.add(Integer.valueOf(point));
+                }
+            }
+        }
+
+        if (pairs.length > 2) {
+            strictOrder = Objects.equals(pairs[2], "1");
+        }
+    }
+
+    private ArrayList<Integer> parsePoints(String cardData) {
+        // 33 - 2025-04-01 10:44:12
+        // 42 - 2025-04-01 10:59:40
+
+        String regex = "(\\d+)\\s+?-\\s+?(\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d)";
+        Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+
+        Matcher matcher = pattern.matcher(cardData);
+
+        ArrayList<Integer> points = new ArrayList<>();
+
+        while (matcher.find()) {
+            points.add(Integer.valueOf(Objects.requireNonNull(matcher.group(1))));
+        }
+
+        return points;
+    }
+
+    public void parse(String cardData) {
+        if (validator == null) {
+            return;
+        }
+
+        this.cardPointsRaw = this.parsePoints(cardData);
+        this.cardPoints = validator.normalizeCardPoints(this.cardPointsRaw);
+    }
+
+    public Boolean isValid() {
+        return validator.isValid();
+    }
+
+    public ArrayList<Integer> getCardPoints() {
+        return cardPoints;
+    }
+
+    public ArrayList<Integer> getCardPointsRaw() {
+        return cardPointsRaw;
+    }
+
+    public ArrayList<Integer> getCoursePoints() {
+        return coursePoints;
+    }
+
+    public ArrayList<Integer> getMissedCoursePoints() {
+        return validator.getMissedCoursePoints();
+    }
+
+    public Integer getScore() {
+        return this.validator.getScore();
+    }
+
+    public Enum<CourseType> getType() {
+        return type;
+    }
+
+    public Boolean isStrictOrder() {
+        return strictOrder;
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/CourseValidatorBase.java
+++ b/app/src/main/java/org/sportiduino/app/CourseValidatorBase.java
@@ -1,0 +1,27 @@
+package org.sportiduino.app;
+
+import java.util.ArrayList;
+
+class CourseValidatorBase {
+    protected CourseValidator validator;
+
+    public CourseValidatorBase(CourseValidator validator) {
+        this.validator = validator;
+    }
+
+    public ArrayList<Integer> normalizeCardPoints(ArrayList<Integer> points) {
+        return points;
+    }
+
+    public Boolean isValid() {
+        return false;
+    }
+
+    public Integer getScore() {
+        return 0;
+    }
+
+    public ArrayList<Integer> getMissedCoursePoints() {
+        return new ArrayList<>();
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/CourseValidatorOrienteering.java
+++ b/app/src/main/java/org/sportiduino/app/CourseValidatorOrienteering.java
@@ -1,0 +1,58 @@
+package org.sportiduino.app;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Objects;
+
+public class CourseValidatorOrienteering extends CourseValidatorBase {
+    public CourseValidatorOrienteering(CourseValidator courseValidator) {
+        super(courseValidator);
+    }
+
+    public ArrayList<Integer> normalizeCardPoints(ArrayList<Integer> points) {
+        ArrayList<Integer> coursePoints = this.validator.getCoursePoints();
+        ArrayList<Integer> normalizedPoints = new ArrayList<>();
+
+        for (Integer point : points) {
+            for (Integer coursePoint : coursePoints) {
+                if (Objects.equals(point, coursePoint)) {
+                    normalizedPoints.add(point);
+                    break;
+                }
+            }
+        }
+
+        return normalizedPoints;
+    }
+
+    public ArrayList<Integer> getMissedCoursePoints() {
+        ArrayList<Integer> coursePoints = this.validator.getCoursePoints();
+        ArrayList<Integer> cardPoints = this.validator.getCardPoints();
+
+        ArrayList<Integer> missedCoursePoints = new ArrayList<>(coursePoints);
+        missedCoursePoints.removeAll(cardPoints);
+
+        return missedCoursePoints;
+    }
+
+    private Boolean isValidPoints() {
+        ArrayList<Integer> coursePoints = this.validator.getCoursePoints();
+        ArrayList<Integer> cardPoints = this.validator.getCardPoints();
+
+        if (!validator.isStrictOrder()) {
+            Collections.sort(coursePoints);
+            Collections.sort(cardPoints);
+        }
+
+        return Arrays.equals(coursePoints.toArray(), cardPoints.toArray());
+    }
+
+    public Boolean isValid() {
+        return this.isValidPoints();
+    }
+
+    public Integer getScore() {
+        return this.validator.getCardPoints().size();
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/CourseValidatorRogaining.java
+++ b/app/src/main/java/org/sportiduino/app/CourseValidatorRogaining.java
@@ -1,0 +1,25 @@
+package org.sportiduino.app;
+
+import java.util.ArrayList;
+
+public class CourseValidatorRogaining extends CourseValidatorBase {
+    public CourseValidatorRogaining(CourseValidator validator) {
+        super(validator);
+    }
+
+    public Boolean isValid() {
+        return !validator.getCardPoints().isEmpty();
+    }
+
+    public Integer getScore() {
+        int score = 0;
+
+        ArrayList<Integer> cardPoints = validator.getCardPoints();
+
+        for (int cardPoint : cardPoints) {
+            score += (int) Math.floor((double) cardPoint / 10);
+        }
+
+        return score;
+    }
+}

--- a/app/src/main/java/org/sportiduino/app/FragmentReadCard.java
+++ b/app/src/main/java/org/sportiduino/app/FragmentReadCard.java
@@ -6,6 +6,8 @@ import android.nfc.tech.MifareClassic;
 import android.nfc.tech.MifareUltralight;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.Html;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,9 +21,11 @@ import org.sportiduino.app.sportiduino.Card;
 import org.sportiduino.app.sportiduino.CardAdapter;
 import org.sportiduino.app.sportiduino.CardMifareClassic;
 import org.sportiduino.app.sportiduino.CardMifareUltralight;
+import org.sportiduino.app.sportiduino.CardType;
 import org.sportiduino.app.sportiduino.ReadWriteCardException;
 import org.sportiduino.app.sportiduino.Util;
 
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.LinkedList;
 import java.util.List;
@@ -30,6 +34,7 @@ public class FragmentReadCard extends NfcFragment {
     private FragmentReadCardBinding binding;
     private View currentView;
     private String cardDataUrl;
+    private CourseValidator courseValidator;
 
     @Override
     public View onCreateView(
@@ -48,6 +53,9 @@ public class FragmentReadCard extends NfcFragment {
 
         SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(Objects.requireNonNull(getContext()));
         this.cardDataUrl = sharedPref.getString("card_data_url", "null");
+
+        String cardDataCourseValidation = sharedPref.getString("card_course_validation", "null");
+        this.courseValidator = new CourseValidator(cardDataCourseValidation);
 
         binding.textViewNfcInfo.setText(R.string.bring_card);
     }
@@ -91,6 +99,7 @@ public class FragmentReadCard extends NfcFragment {
         @Override
         protected void onPreExecute() {
             binding.textViewTagType.setText("");
+            binding.textViewCourseValidationInfo.setVisibility(View.GONE);
             binding.textViewInfo.setVisibility(View.GONE);
             binding.textViewInfo.setText("");
             binding.textViewNfcInfo.setText(R.string.reading_card_dont_remove_it);
@@ -112,6 +121,42 @@ public class FragmentReadCard extends NfcFragment {
                 cardAdapter.close();
             }
             return status;
+        }
+
+        private void handleCourseValidation(CharSequence data) {
+            if (courseValidator.getType() == Course.CourseType.UNKNOWN) {
+                binding.textViewCourseValidationInfo.setVisibility(View.GONE);
+
+                return;
+            }
+
+            courseValidator.parse(data.toString());
+
+            Boolean isCourseValid = courseValidator.isValid();
+
+            String validationText = App.str(isCourseValid ? R.string.course_validation_success : R.string.course_validation_failure);
+            Integer validationColor = isCourseValid ? R.color.green : R.color.red;
+
+            String validationInfo = App.str(R.string.course_validation) +
+                    ": " + Util.coloredHtmlString(validationText, Util.colorToHexCode(validationColor));
+
+            validationInfo += " (";
+
+            validationInfo += courseValidator.getScore() + " points scored";
+
+            if (!isCourseValid) {
+                ArrayList<Integer> missedCoursePoints = courseValidator.getMissedCoursePoints();
+
+                if (!missedCoursePoints.isEmpty()) {
+                    validationInfo += ", missed point" + (missedCoursePoints.size() > 1 ? "s" : "") +
+                            " " + TextUtils.join(", ", missedCoursePoints);
+                }
+            }
+
+            validationInfo += ")";
+
+            binding.textViewCourseValidationInfo.setText(Html.fromHtml(validationInfo));
+            binding.textViewCourseValidationInfo.setVisibility(View.VISIBLE);
         }
 
         private void handleCardDataUrl(CharSequence data) {
@@ -143,7 +188,10 @@ public class FragmentReadCard extends NfcFragment {
                 binding.textViewInfo.setText(data);
                 binding.textViewNfcInfo.setText(Util.ok(getString(R.string.card_read_successfully), currentView));
 
-                handleCardDataUrl(data);
+                if (card.type == CardType.ORDINARY) {
+                    handleCardDataUrl(data);
+                    handleCourseValidation(data);
+                }
             } else {
                 binding.textViewNfcInfo.setText(Util.error(getString(R.string.reading_card_failed), currentView));
             }

--- a/app/src/main/java/org/sportiduino/app/SettingsFragment.java
+++ b/app/src/main/java/org/sportiduino/app/SettingsFragment.java
@@ -43,6 +43,8 @@ public class SettingsFragment extends PreferenceFragmentCompat  implements Prefe
             dialogFragment = NumberPickerPreferenceDialog.newInstance(preference.getKey());
         } else if (preference instanceof CardDataUrlPreference) {
             dialogFragment = CardDataUrlPreferenceDialog.newInstance(preference.getKey());
+        } else if (preference instanceof CardCourseValidationPreference) {
+            dialogFragment = CardCourseValidationPreferenceDialog.newInstance(preference.getKey());
         }
 
         // If it was one of our custom Preferences, show its dialog

--- a/app/src/main/res/layout/fragment_read_card.xml
+++ b/app/src/main/res/layout/fragment_read_card.xml
@@ -39,7 +39,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textIsSelectable="true"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="4dp"
                 android:fontFamily="monospace"/>
+
+            <TextView
+                android:id="@+id/text_view_course_validation_info"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
 
             <TextView
                 android:id="@+id/text_view_card_web_service_info"

--- a/app/src/main/res/layout/preference_card_course_validation.xml
+++ b/app/src/main/res/layout/preference_card_course_validation.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/course_validation_type" />
+
+    <RadioGroup
+        android:id="@+id/course_validation_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/course_validation_type_unknown"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/not_specified" />
+
+        <RadioButton
+            android:id="@+id/course_validation_type_orienteering"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/course_validation_type_orienteering" />
+
+        <RadioButton
+            android:id="@+id/course_validation_type_rogaining"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/course_validation_type_rogaining" />
+    </RadioGroup>
+
+    <LinearLayout
+        android:id="@+id/course_validation_points"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/course_validation_points" />
+        <EditText
+            android:id="@+id/course_validation_points_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textMultiLine"
+            android:gravity="top"
+            android:minLines="1"
+            android:maxLines="10"
+            android:scrollbars="vertical"
+            android:text=""
+            android:autofillHints=""
+            android:hint="@string/course_validation_points_hint" />
+        <CheckBox
+            android:id="@+id/course_validation_points_strict_order"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/course_validation_points_strict_order" />
+    </LinearLayout>
+</LinearLayout>
+

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -97,5 +97,14 @@
     <string name="ntag_auth_key">Ключ защиты Ntag</string>
     <string name="button_ntag_auth_key_reset">Сбросить</string>
     <string name="card_data_url">URL-адрес для отправки данных с чипа</string>
-    <string name="not_specify">не установлено</string>
+    <string name="not_specified">не установлено</string>
+    <string name="course_validation">Проверка пути</string>
+    <string name="course_validation_success">пройдена</string>
+    <string name="course_validation_failure">провалена</string>
+    <string name="course_validation_type">Тип валидации</string>
+    <string name="course_validation_type_orienteering">ориентирование</string>
+    <string name="course_validation_type_rogaining">рогейн</string>
+    <string name="course_validation_points">Контрольные пункты</string>
+    <string name="course_validation_points_hint">список через запятую</string>
+    <string name="course_validation_points_strict_order">Строгий порядок</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,5 +102,14 @@
     <string name="number_1" translatable="false">1</string>
     <string name="number_0" translatable="false">0</string>
     <string name="card_data_url">URL for sending card data</string>
-    <string name="not_specify">not specify</string>
+    <string name="not_specified">not specified</string>
+    <string name="course_validation">Card course validation</string>
+    <string name="course_validation_success">success</string>
+    <string name="course_validation_failure">failure</string>
+    <string name="course_validation_type">Validation type</string>
+    <string name="course_validation_type_orienteering">orienteering</string>
+    <string name="course_validation_type_rogaining">rogaining</string>
+    <string name="course_validation_points">Control points</string>
+    <string name="course_validation_points_hint">comma-separated list</string>
+    <string name="course_validation_points_strict_order">Strict order</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,6 +24,10 @@
         android:title="@string/card_data_url"
         android:summary="" />
 
+    <org.sportiduino.app.CardCourseValidationPreference
+        android:key="card_course_validation"
+        android:title="@string/course_validation"
+        android:summary="" />
 
     <SwitchPreferenceCompat
         android:key="night_mode"


### PR DESCRIPTION
#61 

Added to app settings:

- Validation type selection (not specified, rogaining, orienteering);
- Checkpoint list (for orienteering);
- Strict checkpoint list verification (for orienteering).

Participant card reading:

- The selected validation type is checked and a validation is performed if rogaining or orienteering is selected;
- A message is displayed indicating whether validation has passed or failed.

For rogaining, the presence of at least one punch is currently being checked.

In orienteering, the presence of all punches on the participant’s card is checked (and in the strictly specified order, if there is such a flag).